### PR TITLE
Use latest version of JuliaFormatter again

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache artifacts
         uses: julia-actions/cache@v3
       - name: Install JuliaFormatter and format
-        run: julia -e 'import Pkg; Pkg.add(name="JuliaFormatter", version=v"1.0.62"); using JuliaFormatter; format(".")'
+        run: julia -e 'import Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; format(".")'
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
The latest JuliaFormatter behavior is sufficiently similar to v1. See #49.